### PR TITLE
RSEQNode size should include the header length.

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/RSAR/File Types/RSEQ/RSEQNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/RSAR/File Types/RSEQ/RSEQNode.cs
@@ -20,7 +20,7 @@ namespace BrawlLib.SSBB.ResourceNodes
 
             _dataBuffer = new UnsafeBuffer(Header->_dataLength);
             Memory.Move(_dataBuffer.Address, Header->Data, (uint) Header->_dataLength);
-            SetSizeInternal(Header->_dataLength);
+            SetSizeInternal(Header->_dataLength + Header->_header._firstOffset);
 
             _cmds = MMLParser.Parse(Header->Data + 12);
 


### PR DESCRIPTION
This fixes an issue where exported RSEQ files have their DATA section truncated by 0x20 bytes, shifting the LABL section back 0x20 bytes, etc.