### PR TITLE
Change pointer cast so it doens't overflow

### DIFF
--- a/BrawlLib/SSBB/Types/BRES.cs
+++ b/BrawlLib/SSBB/Types/BRES.cs
@@ -22,7 +22,7 @@ namespace BrawlLib.SSBB.Types
             {
                 fixed (BRESHeader* p = &this)
                 {
-                    return (ROOTHeader*) ((uint) p + _rootOffset);
+                    return (ROOTHeader*)((VoidPtr)p + _rootOffset);
                 }
             }
         }

--- a/BrawlLib/SSBB/Types/Common.cs
+++ b/BrawlLib/SSBB/Types/Common.cs
@@ -654,7 +654,7 @@ namespace BrawlLib.SSBB.Types
                     entry--;
                 }
 
-                return (ResourceGroup*) ((uint) entry - 8);
+                return (ResourceGroup*) ((VoidPtr) entry - 8);
             }
         }
     }


### PR DESCRIPTION
This fixes a bug which caused a crash when opening a BRRES archive.