### PR TITLE
Add support for GLK2 and GLOK Nodes + minor changes to GNDV, GIB2, GET1 Nodes

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLK2Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLK2Node.cs
@@ -1,0 +1,179 @@
+﻿using BrawlLib.Internal;
+using BrawlLib.SSBB.Types.Subspace.Animation;
+using System;
+using System.ComponentModel;
+
+namespace BrawlLib.SSBB.ResourceNodes
+{
+    public unsafe class GLK2Node : BLOCEntryNode
+    {
+        protected override Type SubEntryType => typeof(GLK2EntryNode);
+        public override ResourceType ResourceFileType => ResourceType.Unknown;
+        protected override string baseName => "Camera Locks";
+
+        internal static ResourceNode TryParse(DataSource source, ResourceNode parent)
+        {
+            return source.Tag == "GLK2" ? new GLK2Node() : null;
+        }
+    }
+
+    public unsafe class GLK2EntryNode : ResourceNode
+    {
+        internal GLK2Entry* Header => (GLK2Entry*)WorkingUncompressed.Address;
+        public override ResourceType ResourceFileType => ResourceType.Unknown;
+
+        public int _unkown0x00;
+        public byte _unkflag1;
+        public byte _unkflag2;
+        public byte _unkflag3;
+        public byte _unkflag4;
+        public uint _trigger1;
+        public uint _trigger2;
+        public uint _trigger3;
+        public uint _trigger4;
+
+        [Category("Camera")]
+        [DisplayName("Unk0")]
+        public int Unk1
+        {
+            get => _unkown0x00;
+            set
+            {
+                _unkown0x00 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Model Data Node")]
+        [Description("File Index to stgposition model to use for this lock.")]
+        public byte ModelDataID
+        {
+            get => _unkflag1;
+            set
+            {
+                _unkflag1 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Unk2")]
+        public byte Unk2
+        {
+            get => _unkflag2;
+            set
+            {
+                _unkflag2 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Unk3")]
+        public byte Unk3
+        {
+            get => _unkflag3;
+            set
+            {
+                _unkflag3 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Unk4")]
+        public byte Unk4
+        {
+            get => _unkflag4;
+            set
+            {
+                _unkflag4 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger1")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger1
+        {
+            get => _trigger1;
+            set
+            {
+                _trigger1 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger2")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger2
+        {
+            get => _trigger2;
+            set
+            {
+                _trigger2 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger3")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger3
+        {
+            get => _trigger3;
+            set
+            {
+                _trigger3 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger4")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger4
+        {
+            get => _trigger4;
+            set
+            {
+                _trigger4 = value;
+                SignalPropertyChange();
+            }
+        }
+
+        public override bool OnInitialize()
+        {
+            _unkown0x00 = Header->_unknown0x00;
+            _unkflag1 = Header->_unkflag1;
+            _unkflag2 = Header->_unkflag2;
+            _unkflag3 = Header->_unkflag3;
+            _unkflag4 = Header->_unkflag4;
+            _trigger1 = Header->_trigger1;
+            _trigger2 = Header->_trigger2;
+            _trigger3 = Header->_trigger3;
+            _trigger4 = Header->_trigger4;
+
+            if (_name == null)
+            {
+                _name = "Locked Zone [" + Index + "]";
+            }
+
+            return false;
+        }
+
+        public override int OnCalculateSize(bool force)
+        {
+            return GLK2Entry.SIZE;
+        }
+
+        public override void OnRebuild(VoidPtr address, int length, bool force)
+        {
+            GLK2Entry* hdr = (GLK2Entry*)address;
+            hdr->_unknown0x00 = _unkown0x00;
+            hdr->_unkflag1 = _unkflag1;
+            hdr->_unkflag2 = _unkflag2;
+            hdr->_unkflag3 = _unkflag3;
+            hdr->_unkflag4 = _unkflag4;
+            hdr->_trigger1 = _trigger1;
+            hdr->_trigger2 = _trigger2;
+            hdr->_trigger3 = _trigger3;
+            hdr->_trigger4 = _trigger4;
+        }
+    }
+}

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLK2Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLK2Node.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace BrawlLib.SSBB.ResourceNodes
 {
-    public unsafe class GLK2Node : BLOCEntryNode
+    public class GLK2Node : BLOCEntryNode
     {
         protected override Type SubEntryType => typeof(GLK2EntryNode);
         public override ResourceType ResourceFileType => ResourceType.Unknown;
@@ -22,15 +22,15 @@ namespace BrawlLib.SSBB.ResourceNodes
         internal GLK2Entry* Header => (GLK2Entry*)WorkingUncompressed.Address;
         public override ResourceType ResourceFileType => ResourceType.Unknown;
 
-        public int _unkown0x00;
-        public byte _unkflag1;
-        public byte _unkflag2;
-        public byte _unkflag3;
-        public byte _unkflag4;
-        public uint _trigger1;
-        public uint _trigger2;
-        public uint _trigger3;
-        public uint _trigger4;
+        private int _unkown0x00;
+        private byte _unkflag1;
+        private byte _unkflag2;
+        private byte _unkflag3;
+        private byte _unkflag4;
+        private uint _trigger1;
+        private uint _trigger2;
+        private uint _trigger3;
+        private uint _trigger4;
 
         [Category("Camera")]
         [DisplayName("Unk0")]

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLOKNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLOKNode.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace BrawlLib.SSBB.ResourceNodes
 {
-    public unsafe class GLOKNode : BLOCEntryNode
+    public class GLOKNode : BLOCEntryNode
     {
         protected override Type SubEntryType => typeof(GLK2EntryNode);
         public override ResourceType ResourceFileType => ResourceType.Unknown;
@@ -22,15 +22,15 @@ namespace BrawlLib.SSBB.ResourceNodes
         internal GLOKEntry* Header => (GLOKEntry*)WorkingUncompressed.Address;
         public override ResourceType ResourceFileType => ResourceType.Unknown;
 
-        public int _unkown0x00;
-        public byte _unkflag1;
-        public byte _unkflag2;
-        public byte _unkflag3;
-        public byte _unkflag4;
-        public uint _trigger1;
-        public uint _trigger2;
-        public uint _trigger3;
-        public uint _trigger4;
+        private int _unkown0x00;
+        private byte _unkflag1;
+        private byte _unkflag2;
+        private byte _unkflag3;
+        private byte _unkflag4;
+        private uint _trigger1;
+        private uint _trigger2;
+        private uint _trigger3;
+        private uint _trigger4;
 
         [Category("Camera")]
         [DisplayName("Unk0")]

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLOKNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Animation/GLOKNode.cs
@@ -1,0 +1,171 @@
+﻿using BrawlLib.Internal;
+using BrawlLib.SSBB.Types.Subspace.Animation;
+using System;
+using System.ComponentModel;
+
+namespace BrawlLib.SSBB.ResourceNodes
+{
+    public unsafe class GLOKNode : BLOCEntryNode
+    {
+        protected override Type SubEntryType => typeof(GLK2EntryNode);
+        public override ResourceType ResourceFileType => ResourceType.Unknown;
+        protected override string baseName => "Camera Scroll Locks";
+
+        internal static ResourceNode TryParse(DataSource source, ResourceNode parent)
+        {
+            return source.Tag == "GLOK" ? new GLOKNode() : null;
+        }
+    }
+
+    public unsafe class GLOKEntryNode : ResourceNode
+    {
+        internal GLOKEntry* Header => (GLOKEntry*)WorkingUncompressed.Address;
+        public override ResourceType ResourceFileType => ResourceType.Unknown;
+
+        public int _unkown0x00;
+        public byte _unkflag1;
+        public byte _unkflag2;
+        public byte _unkflag3;
+        public byte _unkflag4;
+        public uint _trigger1;
+        public uint _trigger2;
+        public uint _trigger3;
+        public uint _trigger4;
+
+        [Category("Camera")]
+        [DisplayName("Unk0")]
+        public int Unk1
+        {
+            get => _unkown0x00;
+            set
+            {
+                _unkown0x00 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Model Data Node")]
+        [Description("File Index to stgposition model to use for this lock.")]
+        public byte ModelDataID
+        {
+            get => _unkflag1;
+            set
+            {
+                _unkflag1 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Unk2")]
+        public byte Unk2
+        {
+            get => _unkflag2;
+            set
+            {
+                _unkflag2 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Unk3")]
+        public byte Unk3
+        {
+            get => _unkflag3;
+            set
+            {
+                _unkflag3 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Unk4")]
+        public byte Unk4
+        {
+            get => _unkflag4;
+            set
+            {
+                _unkflag4 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger1")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger1
+        {
+            get => _trigger1;
+            set
+            {
+                _trigger1 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger2")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger2
+        {
+            get => _trigger2;
+            set
+            {
+                _trigger2 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger3")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger3
+        {
+            get => _trigger3;
+            set
+            {
+                _trigger3 = value;
+                SignalPropertyChange();
+            }
+        }
+        [Category("Camera")]
+        [DisplayName("Trigger4")]
+        [TypeConverter(typeof(HexTypeConverter))]
+        public uint Trigger4
+        {
+            get => _trigger4;
+            set
+            {
+                _trigger4 = value;
+                SignalPropertyChange();
+            }
+        }
+
+        public override bool OnInitialize()
+        {
+            _unkown0x00 = Header->_unknown0x00;
+            _unkflag1 = Header->_unkflag1;
+            _unkflag2 = Header->_unkflag2;
+            _unkflag3 = Header->_unkflag3;
+            _unkflag4 = Header->_unkflag4;
+            _trigger1 = Header->_trigger1;
+            _trigger2 = Header->_trigger2;
+            _trigger3 = Header->_trigger3;
+            _trigger4 = Header->_trigger4;
+
+            if (_name == null)
+            {
+                _name = "Scroll Lock [" + Index + "]";
+            }
+
+            return false;
+        }
+
+        public override int OnCalculateSize(bool force)
+        {
+            return GLOKEntry.SIZE;
+        }
+
+        public override void OnRebuild(VoidPtr address, int length, bool force)
+        {
+            GLOKEntry* hdr = (GLOKEntry*)address;
+
+        }
+    }
+}

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Graphics/GNDVNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Graphics/GNDVNode.cs
@@ -63,6 +63,7 @@ namespace BrawlLib.SSBB.ResourceNodes
 
         [Category("General")]
         [DisplayName("Graphic ID")]
+        [TypeConverter(typeof(HexTypeConverter))]
         public uint Graphic
         {
             get => _gfx;
@@ -77,6 +78,7 @@ namespace BrawlLib.SSBB.ResourceNodes
 
         [Category("Triggers")]
         [DisplayName("TriggerID")]
+        [TypeConverter(typeof(HexTypeConverter))]
         public uint TriggerID
         {
             get => _triggerID;

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Objects/GIB2Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Objects/GIB2Node.cs
@@ -75,11 +75,9 @@ namespace BrawlLib.SSBB.ResourceNodes
         public byte _unknown0x41;
         public byte _unknown0x42;
         public byte _unknown0x43;
-        public byte _unknown0x44;
-        public byte _unkflag9;
+        public short _unkflag9;
         public byte _unkflag10;
         public byte _unkflag11;
-        public byte _unkflag12;
         public uint _trigger1;
         public uint _trigger2;
         public uint _trigger3;
@@ -197,7 +195,7 @@ namespace BrawlLib.SSBB.ResourceNodes
 
         [Category("Item Box")]
         [DisplayName("Unk9")]
-        public byte Unk9
+        public short Unk9
         {
             get => _unkflag9;
             set
@@ -227,18 +225,6 @@ namespace BrawlLib.SSBB.ResourceNodes
             set
             {
                 _unkflag11 = value;
-                SignalPropertyChange();
-            }
-        }
-
-        [Category("Item Box")]
-        [DisplayName("Unk12")]
-        public byte Unk12
-        {
-            get => _unkflag12;
-            set
-            {
-                _unkflag12 = value;
                 SignalPropertyChange();
             }
         }
@@ -337,7 +323,6 @@ namespace BrawlLib.SSBB.ResourceNodes
             _unknown0x41 = Header->_unknown0x41;
             _unknown0x42 = Header->_unknown0x42;
             _unknown0x43 = Header->_unknown0x43;
-            _unknown0x44 = Header->_unknown0x44;
             _unkflag9 = Header->_unkflag9;
             _unkflag10 = Header->_unkflag10;
             _unkflag11 = Header->_unkflag11;
@@ -413,7 +398,6 @@ namespace BrawlLib.SSBB.ResourceNodes
             hdr->_unknown0x41 = _unknown0x41;
             hdr->_unknown0x42 = _unknown0x42;
             hdr->_unknown0x43 = _unknown0x43;
-            hdr->_unknown0x44 = _unknown0x44;
             hdr->_unkflag9 = _unkflag9;
             hdr->_unkflag10 = _unkflag10;
             hdr->_unkflag11 = _unkflag11;

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Triggers/GET1Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Triggers/GET1Node.cs
@@ -50,7 +50,7 @@ namespace BrawlLib.SSBB.ResourceNodes
 
         [Category("Triggers")]
         [DisplayName("Trigger1")]
-        //[TypeConverter(typeof(UInt32HexTypeConverter))]
+        [TypeConverter(typeof(HexTypeConverter))]
         public uint Trigger
         {
             get => _trigger1;
@@ -65,7 +65,7 @@ namespace BrawlLib.SSBB.ResourceNodes
 
         [Category("Triggers")]
         [DisplayName("Trigger2")]
-        //[TypeConverter(typeof(UInt32HexTypeConverter))]
+        [TypeConverter(typeof(HexTypeConverter))]
         public uint Trigger2
         {
             get => _trigger2;

--- a/BrawlLib/SSBB/Types/Subspace/Animation/GLK2.cs
+++ b/BrawlLib/SSBB/Types/Subspace/Animation/GLK2.cs
@@ -6,7 +6,7 @@ namespace BrawlLib.SSBB.Types.Subspace.Animation
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public unsafe struct GLK2Entry
     {
-        public const int SIZE = 0x18;
+        public static readonly int SIZE = 0x18;
 
         public bint _unknown0x00;
         public byte _unkflag1;
@@ -17,16 +17,5 @@ namespace BrawlLib.SSBB.Types.Subspace.Animation
         public buint _trigger2;
         public buint _trigger3;
         public buint _trigger4;
-
-        private VoidPtr Address
-        {
-            get
-            {
-                fixed (void* ptr = &this)
-                {
-                    return ptr;
-                }
-            }
-        }
     }
 }

--- a/BrawlLib/SSBB/Types/Subspace/Animation/GLK2.cs
+++ b/BrawlLib/SSBB/Types/Subspace/Animation/GLK2.cs
@@ -1,0 +1,32 @@
+﻿using BrawlLib.Internal;
+using System.Runtime.InteropServices;
+
+namespace BrawlLib.SSBB.Types.Subspace.Animation
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public unsafe struct GLK2Entry
+    {
+        public const int SIZE = 0x18;
+
+        public bint _unknown0x00;
+        public byte _unkflag1;
+        public byte _unkflag2;
+        public byte _unkflag3;
+        public byte _unkflag4;
+        public buint _trigger1;
+        public buint _trigger2;
+        public buint _trigger3;
+        public buint _trigger4;
+
+        private VoidPtr Address
+        {
+            get
+            {
+                fixed (void* ptr = &this)
+                {
+                    return ptr;
+                }
+            }
+        }
+    }
+}

--- a/BrawlLib/SSBB/Types/Subspace/Animation/GLOK.cs
+++ b/BrawlLib/SSBB/Types/Subspace/Animation/GLOK.cs
@@ -1,0 +1,32 @@
+﻿using BrawlLib.Internal;
+using System.Runtime.InteropServices;
+
+namespace BrawlLib.SSBB.Types.Subspace.Animation
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public unsafe struct GLOKEntry
+    {
+        public const int SIZE = 0x18;
+
+        public bint _unknown0x00;
+        public byte _unkflag1;
+        public byte _unkflag2;
+        public byte _unkflag3;
+        public byte _unkflag4;
+        public buint _trigger1;
+        public buint _trigger2;
+        public buint _trigger3;
+        public buint _trigger4;
+
+        private VoidPtr Address
+        {
+            get
+            {
+                fixed (void* ptr = &this)
+                {
+                    return ptr;
+                }
+            }
+        }
+    }
+}

--- a/BrawlLib/SSBB/Types/Subspace/Animation/GLOK.cs
+++ b/BrawlLib/SSBB/Types/Subspace/Animation/GLOK.cs
@@ -6,7 +6,7 @@ namespace BrawlLib.SSBB.Types.Subspace.Animation
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public unsafe struct GLOKEntry
     {
-        public const int SIZE = 0x18;
+        public static readonly int SIZE = 0x18;
 
         public bint _unknown0x00;
         public byte _unkflag1;
@@ -17,16 +17,5 @@ namespace BrawlLib.SSBB.Types.Subspace.Animation
         public buint _trigger2;
         public buint _trigger3;
         public buint _trigger4;
-
-        private VoidPtr Address
-        {
-            get
-            {
-                fixed (void* ptr = &this)
-                {
-                    return ptr;
-                }
-            }
-        }
     }
 }

--- a/BrawlLib/SSBB/Types/Subspace/Objects/GIB2.cs
+++ b/BrawlLib/SSBB/Types/Subspace/Objects/GIB2.cs
@@ -61,8 +61,7 @@ namespace BrawlLib.SSBB.Types.Subspace.Objects
         public byte _unknown0x41;
         public byte _unknown0x42;
         public byte _unknown0x43;
-        public byte _unknown0x44;
-        public byte _unkflag9;
+        public bshort _unkflag9;
         public byte _unkflag10;
         public byte _unkflag11;
         public buint _trigger1;


### PR DESCRIPTION
This PR adds support for `GLK2` and `GLOK` Nodes (SSE Camera locks and Camera Scroll Locks) and brings them to fully usable status. Also includes a minor cleanup for `GNDV`, `GET1`, and `GIB2` nodes.

- Add support for `GLK2` and `GLOK` Nodes (SSE Camera Locks)
- Update `GNDV` and `GET1` to use new `HexTypeConverter` for TriggerID's and etc
- Fix some fields in `GIB2` nodes.