### PR TITLE
GIB2EntryNode doesn't support compression

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/Subspace/Objects/GIB2Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/Objects/GIB2Node.cs
@@ -21,6 +21,7 @@ namespace BrawlLib.SSBB.ResourceNodes
     {
         internal GIB2Entry* Header => (GIB2Entry*) WorkingUncompressed.Address;
         public override ResourceType ResourceFileType => ResourceType.Unknown;
+        public override bool supportsCompression => false;
 
         public bfloat _header;
         public byte _unknown0x04;


### PR DESCRIPTION
Fixes crash on replacing GIB2EntryNodes.