### PR TITLE
When making all files external, don't add a leading '/'

### DIFF
--- a/BrawlLib/Internal/Windows/Controls/SoundPackControl.cs
+++ b/BrawlLib/Internal/Windows/Controls/SoundPackControl.cs
@@ -616,11 +616,11 @@ namespace BrawlLib.Internal.Windows.Controls
 
                 ListViewItem v = i;
                 string type = v.SubItems[1].Text;
-                string dir = "\\" + type + "\\";
+                string dir = type + "\\";
                 string fileName = i._node.Name.Replace('/', '_').Replace('<', '(').Replace('>', ')') + ".b" +
                                   type.ToLower();
 
-                string newPath = _targetNode._origPath.Substring(0, _targetNode._origPath.LastIndexOf('\\')) + dir;
+                string newPath = _targetNode._origPath.Substring(0, _targetNode._origPath.LastIndexOf('\\')) + "\\" + dir;
                 if (!Directory.Exists(newPath))
                 {
                     Directory.CreateDirectory(newPath);


### PR DESCRIPTION
Previously this produced external paths like the following: `/RSEQ/[171] RP_SSN_SE_CLIPMENU_GROUP.brseq`
Instead, it should produce paths like this: `RSEQ/[171] RP_SSN_SE_CLIPMENU_GROUP.brseq` which matches external files already found in brsars such as `stream/Clp_Menu_BGM01_lr.n.32.brstm`

I'd like to note that I haven't tested this yet, as I don't have a convenient setup for brawlcrate dev atm, so that's why it's a marked as a draft PR.