### PR TITLE
Fix InitialStreamWrapper

### DIFF
--- a/BrawlLib/Internal/Windows/Forms/BrstmConverterDialog.cs
+++ b/BrawlLib/Internal/Windows/Forms/BrstmConverterDialog.cs
@@ -40,9 +40,24 @@ namespace BrawlLib.Internal.Windows.Forms
                 set => BaseStream.SamplePosition = value;
             }
 
-            public int ReadSamples(VoidPtr destAddr, int numSamples)
-            {
-                return BaseStream.ReadSamples(destAddr, numSamples);
+            public unsafe int ReadSamples(VoidPtr destAddr, int numSamples) {
+                if (BaseStream.Channels <= 2) {
+                    return BaseStream.ReadSamples(destAddr, numSamples);
+                } else {
+                    int r = 0;
+                    short* out_ptr = (short*)(void*)destAddr;
+                    short[] buffer = new short[BaseStream.Channels];
+                    fixed (short* buffer_ptr = buffer) {
+                        while (r < numSamples) {
+                            int q = BaseStream.ReadSamples(buffer_ptr, 1);
+                            r += q;
+                            *out_ptr++ = buffer[0];
+                            *out_ptr++ = buffer[1];
+                            if (q == 0) break;
+                        }
+                    }
+                    return r;
+                }
             }
 
             public void Wrap()

--- a/BrawlLib/Internal/Windows/Forms/BrstmConverterDialog.cs
+++ b/BrawlLib/Internal/Windows/Forms/BrstmConverterDialog.cs
@@ -47,7 +47,7 @@ namespace BrawlLib.Internal.Windows.Forms
 
             public void Wrap()
             {
-                BaseStream.Wrap();
+                SamplePosition = LoopStartSample;
             }
 
             public void Dispose()


### PR DESCRIPTION
Fix Wrap() function of InitialStreamWrapper so the loop point specified in the window is used, not the initial one, and handle streams with more than two channels.

These are fixes backported from LoopingAudioConverter - I'd like to just include BrawlLib wholesale in the next version so I can also  offer its audio encoder as an option instead of VGAudio.