### PR TITLE
CSTMConverter / RSTMConverter unmanaged memory fixes

### DIFF
--- a/BrawlLib/Wii/Audio/CSTMConverter.cs
+++ b/BrawlLib/Wii/Audio/CSTMConverter.cs
@@ -67,7 +67,8 @@ namespace BrawlLib.Wii.Audio
 
                 VoidPtr dataFrom = rstm->DATAData->Data;
                 VoidPtr dataTo = data->Data;
-                Memory.Move(dataTo, dataFrom, (uint) data->_length - 8);
+                VoidPtr dataEnd = address + array.LongLength;
+                Memory.Move(dataTo, dataFrom, (uint) (dataEnd - dataTo));
             }
 
             return array;

--- a/BrawlLib/Wii/Audio/FSTMConverter.cs
+++ b/BrawlLib/Wii/Audio/FSTMConverter.cs
@@ -67,7 +67,8 @@ namespace BrawlLib.Wii.Audio
 
                 VoidPtr dataFrom = rstm->DATAData->Data;
                 VoidPtr dataTo = data->Data;
-                Memory.Move(dataTo, dataFrom, (uint) data->_length);
+                VoidPtr dataEnd = address + array.LongLength;
+                Memory.Move(dataTo, dataFrom, (uint)(dataEnd - dataTo));
             }
 
             return array;


### PR DESCRIPTION
Stop CSTMConverter and RSTMConverter copying past the end of both input and output addresses