### PR TITLE
IsDirty Now Checks BRSAR Files for Changes

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/RSAR/RSARNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/RSAR/RSARNode.cs
@@ -16,6 +16,64 @@ namespace BrawlLib.SSBB.ResourceNodes
         internal RSARHeader* Header => (RSARHeader*) WorkingSource.Address;
         public override ResourceType ResourceFileType => ResourceType.RSAR;
 
+        public override bool IsDirty
+        {
+            get
+            {
+                if (!AllowSaving)
+                {
+                    return false;
+                }
+
+                if (HasChanged)
+                {
+                    return true;
+                }
+
+                if (_children != null)
+                {
+                    foreach (ResourceNode n in _children)
+                    {
+                        if (n.HasChanged || n.IsBranch || n.IsDirty)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                if (Files != null)
+                {
+                    foreach (ResourceNode n in Files)
+                    {
+                        if (n.HasChanged || n.IsBranch || n.IsDirty)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+            set
+            {
+                _changed = value;
+                if (_children != null)
+                {
+                    foreach (ResourceNode r in Children)
+                    {
+                        if (r._children != null)
+                        {
+                            r.IsDirty = value;
+                        }
+                        else
+                        {
+                            r._changed = value;
+                        }
+                    }
+                }
+            }
+        }
+
         [Category("Sound Archive")]
         public ushort SeqSoundCount
         {


### PR DESCRIPTION
Fixes an issue which prevented certain changes in BRSAR files (eg. changing sound params) from flagging the RSAR node as dirty, preventing those changes from being saved.

This happens because the ResourceNode IsDirty check only looks at proper node children, ignoring the RSAR's Files list, which is where the changes being ignored are located.

Giving the RSAR node an override for the IsDirty check which does check the Files list fixes the problem.