### PR TITLE
AnimFormat : change "weighted" to 0

### DIFF
--- a/BrawlLib/Wii/Animations/AnimFormat.cs
+++ b/BrawlLib/Wii/Animations/AnimFormat.cs
@@ -68,7 +68,7 @@ namespace BrawlLib.Wii.Animations
                         file.WriteLine("animData {");
                         file.WriteLine("  input time;");
                         file.WriteLine($"  output {(index > 2 && index < 6 ? "angular" : "linear")};");
-                        file.WriteLine("  weighted 1;");
+                        file.WriteLine("  weighted 0;");
                         file.WriteLine("  preInfinity constant;");
                         file.WriteLine("  postInfinity constant;");
                         file.WriteLine("  keys {");


### PR DESCRIPTION
Wii tangents aren't weighted; being set to "1" breaks animations (usually shaking) when opened in Maya etc