### PR TITLE
Fix U8 tree corruption when saving

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
@@ -183,7 +183,7 @@ namespace BrawlLib.SSBB.ResourceNodes
                     }
                     else
                     {
-                        curIndex = ((U8EntryNode)nextParent).Index - 1;
+                        curIndex = ((U8EntryNode)nextParent).Index + 1;
                         nextParent = nextParent.Parent;
                     }
                 }

--- a/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
@@ -96,7 +96,7 @@ namespace BrawlLib.SSBB.ResourceNodes
                     while (t != null)
                     {
                         t.Parent = x;
-                        if (t._u8Index + 1 < nodes.Count && t.ChildEndIndex != nodes[t._u8Index + 1]._u8Index)
+                        if (t._u8Index + 1 < nodes.Count && x.ChildEndIndex - 1 != nodes[t._u8Index + 1]._u8Index)
                         {
                             t = nodes[t._u8Index + 1];
                         }
@@ -172,11 +172,19 @@ namespace BrawlLib.SSBB.ResourceNodes
                     parentIndex = ((U8EntryNode) node.Parent)._u8Index;
                 }
 
-                if (index < node.Parent?.Children.Count)
-                {
-                    if (node.Parent.Children[index] is U8EntryNode u8en)
+                ResourceNode nextParent = node.Parent;
+                int curIndex = index;
+                while (nextParent != null && nextParent != this)
+                { 
+                    if (curIndex < nextParent?.Children.Count && nextParent.Children[curIndex] is U8EntryNode u8en)
                     {
                         endIndex = u8en._u8Index;
+                        break;
+                    }
+                    else
+                    {
+                        curIndex = ((U8EntryNode)nextParent)._u8Index - 1;
+                        nextParent = nextParent.Parent;
                     }
                 }
 

--- a/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
@@ -183,7 +183,7 @@ namespace BrawlLib.SSBB.ResourceNodes
                     }
                     else
                     {
-                        curIndex = ((U8EntryNode)nextParent)._u8Index - 1;
+                        curIndex = ((U8EntryNode)nextParent).Index - 1;
                         nextParent = nextParent.Parent;
                     }
                 }


### PR DESCRIPTION
BrawlCrate for a long time had issues with the U8 tree when saving any changes, or no changes at all in some cases. This was caused by two seperate bugs that influenced the value of the `dataLength` value in directory nodes: 

1. An off-by-one error when opening the archive combined with a `ChildEndIndex` check on a child node instead of the parent directory caused directories to be wrongfully put under a subdirectory of a sibling directory, something that would not be visible in the tree view because the tree view uses the parent idx field from the imported file instead.
2. The last subdirectory in any directory would automatically put every single other node that followed in the tree under itself, as it unintendedly used a fallback value (the end of the tree).

Both points are addressed in this PR and U8 archives are now properly saved in the correct format.