### PR TITLE
[BrawlLib] RASDNode > Don't replace the name

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/RASDNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/RASDNode.cs
@@ -16,7 +16,6 @@ namespace BrawlLib.SSBB.ResourceNodes
         {
             base.OnInitialize();
             //SetSizeInternal(Header->_header._length);
-            _name = "RASD" + Index;
             return false;
         }
 


### PR DESCRIPTION
An artifact way back from original BrawlBox. As simple as this change is, it allows for correct saving of these files.