### PR TITLE
CLR0s With UserData No Longer Crash on PostProcess

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/Animations/CLR0Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Animations/CLR0Node.cs
@@ -269,9 +269,9 @@ namespace BrawlLib.SSBB.ResourceNodes
             int index = 1;
             foreach (CLR0MaterialNode n in Children)
             {
-                dataAddress = (VoidPtr) group + (rEntry++)->_dataOffset;
-                ResourceEntry.Build(group, index++, dataAddress, (BRESString*) stringTable[n.Name]);
-                n.PostProcess(dataAddress, stringTable);
+                VoidPtr materialDataAddress = (VoidPtr) group + (rEntry++)->_dataOffset;
+                ResourceEntry.Build(group, index++, materialDataAddress, (BRESString*) stringTable[n.Name]);
+                n.PostProcess(materialDataAddress, stringTable);
             }
 
             if (_version == 4)


### PR DESCRIPTION
Previously, attempting to save a CLR0 that had UserData entries defined would crash the program. This happened because the block that does the PostProcess calls for the CLR0MaterialNodes was changing the value of the dataAddress parameter before we reached the UserEntries PostProcess call; so the _userEntries.PostProcess() call was being done with a bad address parameter. Fixed by giving the CLR0MaterialNode block a local variable for holding the addresses it uses so it doesn't overwrite the original parameter.