### PR TITLE
Fix collada dae import for geometry with shared input offsets

### DIFF
--- a/BrawlLib/Internal/Matrix.cs
+++ b/BrawlLib/Internal/Matrix.cs
@@ -984,7 +984,7 @@ namespace BrawlLib.Internal
                     }
                     else
                     {
-                        x = (float) Math.Atan2(p[4], -p[8]);
+                        x = (float) Math.Atan2(-p[4], -p[8]);
                     }
                 }
                 else

--- a/BrawlLib/Modeling/Collada/ColladaParser.cs
+++ b/BrawlLib/Modeling/Collada/ColladaParser.cs
@@ -669,7 +669,9 @@ namespace BrawlLib.Modeling.Collada
                 PrimitiveEntry prim = new PrimitiveEntry {_type = type};
                 PrimitiveFace p;
                 int val;
-                int stride = 0, elements = 0;
+                int stride = 0;
+                HashSet<int> uniqueOffsets = new HashSet<int>();
+                int elements = 0;
 
                 switch (type)
                 {
@@ -706,21 +708,23 @@ namespace BrawlLib.Modeling.Collada
                 {
                     if (_reader.Name.Equals("input", true))
                     {
-                        prim._inputs.Add(ParseInput());
-                        elements++;
+                        InputEntry entry = ParseInput();
+                        prim._inputs.Add(entry);
+                        uniqueOffsets.Add(entry._offset);
+                        ++elements;
                     }
                     else if (_reader.Name.Equals("p", true))
                     {
-                        List<ushort> indices = new List<ushort>(stride * elements);
+                        List<ushort> indices = new List<ushort>(stride * uniqueOffsets.Count);
 
                         p = new PrimitiveFace();
-                        //p._pointIndices.Capacity = stride * elements;
+                        //p._pointIndices.Capacity = stride * uniqueOffsets.Count;
                         while (_reader.ReadValue(&val))
                         {
                             indices.Add((ushort) val);
                         }
 
-                        p._pointCount = indices.Count / elements;
+                        p._pointCount = indices.Count / uniqueOffsets.Count;
                         p._pointIndices = indices.ToArray();
 
                         switch (type)


### PR DESCRIPTION
The Collada dae importer was not accounting for geometries that used inputs with shared offset values and assumed that there are always as many indices per facePoint as there were inputs.

This was causing the decoder to read/write vertices and indices to/from the wrong memory addresses, which can cause undefined behavior.

For example, if the geometry had the below inputs
```
<triangles material="material" count="3864">`
  <input semantic="VERTEX" source="#vertices" offset="0"/>
  <input semantic="NORMAL" source="#normals" offset="1"/>
  <input semantic="TEXCOORD" source="#map-0" offset="2" set="0"/>
  <input semantic="TEXCOORD" source="#map-1" offset="2" set="1"/>
  <p>287 0 0 288 1 1 286 2 2 0 3 3 ...
```
This means there are 3 index values for each face point, but the parser assumed there's 4 since there's 4 inputs.
The first triangle in this list would be pulling positions from index 287, 1, and 2 when it should be pulling from index 287, 288, and 286

This code change should help BC from silently crashing/creating garbled models when importing some dae files that would otherwise work in other tools.

Note: The dae files that ran into this issue were exported from blender 3.6.
This code has been tested and confirmed working with 2 dae files that were known to be working prior to this change.
It has **_not_** been tested against any files that contain vertex colors.