### PR TITLE
Move/Rotate/Scale tool buttons instead of a Drop Down

### DIFF
--- a/BrawlCrate/UI/Model Previewer/ModelEditControl/Designer.cs
+++ b/BrawlCrate/UI/Model Previewer/ModelEditControl/Designer.cs
@@ -144,7 +144,6 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
         public ToolStripMenuItem chkBRRESAnims;
         private ToolStripButton chkZoomExtents;
         private ToolStripSeparator toolStripSeparator2;
-        private ToolStripComboBox cboToolSelect;
         private ToolStripDropDownButton dropdownOverlays;
         private ToolStripMenuItem chkAllOverlays;
         private ToolStripMenuItem chkBoundaries;
@@ -180,6 +179,9 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
         private ToolStripMenuItem btnWeightEditor;
         private ToolStripMenuItem btnVertexEditor;
         private ToolStripMenuItem toggleMetals;
+        private ToolStripButton chkToolTranslate;
+        private ToolStripButton chkToolRotate;
+        private ToolStripButton chkToolScale;
         public RightPanel rightPanel;
 
         private void InitializeComponent()
@@ -330,7 +332,9 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
             chkZoomExtents = new ToolStripButton();
             btnSaveCam = new ToolStripButton();
             toolStripSeparator2 = new ToolStripSeparator();
-            cboToolSelect = new ToolStripComboBox();
+            chkToolTranslate = new ToolStripButton();
+            chkToolRotate = new ToolStripButton();
+            chkToolScale = new ToolStripButton();
             panel2 = new Panel();
             spltRight = new Splitter();
             panel1 = new Panel();
@@ -1574,21 +1578,21 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
             toolStrip1.Dock = DockStyle.Fill;
             toolStrip1.GripStyle = ToolStripGripStyle.Hidden;
             toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            toolStrip1.Items.AddRange(new ToolStripItem[]
-            {
-                chkBones,
-                chkPolygons,
-                chkVertices,
-                chkCollisions,
-                dropdownOverlays,
-                toolStripSeparator1,
-                chkFloor,
-                button1,
-                chkZoomExtents,
-                btnSaveCam,
-                toolStripSeparator2,
-                cboToolSelect
-            });
+            toolStrip1.Items.AddRange(new ToolStripItem[] {
+            chkBones,
+            chkPolygons,
+            chkVertices,
+            chkCollisions,
+            dropdownOverlays,
+            toolStripSeparator1,
+            chkFloor,
+            button1,
+            chkZoomExtents,
+            btnSaveCam,
+            toolStripSeparator2,
+            chkToolTranslate,
+            chkToolRotate,
+            chkToolScale});
             toolStrip1.Location = new System.Drawing.Point(464, 0);
             toolStrip1.Name = "toolStrip1";
             toolStrip1.Padding = new Padding(6, 0, 0, 0);
@@ -1737,20 +1741,35 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
             toolStripSeparator2.Name = "toolStripSeparator2";
             toolStripSeparator2.Size = new System.Drawing.Size(6, 6);
             // 
-            // cboToolSelect
+            // chkToolTranslate
             // 
-            cboToolSelect.DropDownStyle = ComboBoxStyle.DropDownList;
-            cboToolSelect.FlatStyle = FlatStyle.Standard;
-            cboToolSelect.Items.AddRange(new object[]
-            {
-                "Translation",
-                "Rotation",
-                "Scale",
-                "None"
-            });
-            cboToolSelect.Name = "cboToolSelect";
-            cboToolSelect.Size = new System.Drawing.Size(121, 28);
-            cboToolSelect.SelectedIndexChanged += new EventHandler(cboToolSelect_SelectedIndexChanged);
+            chkToolTranslate.CheckOnClick = true;
+            chkToolTranslate.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            chkToolTranslate.ImageTransparentColor = System.Drawing.Color.Magenta;
+            chkToolTranslate.Name = "chkToolTranslate";
+            chkToolTranslate.Size = new System.Drawing.Size(41, 19);
+            chkToolTranslate.Text = "Move";
+            chkToolTranslate.CheckedChanged += new EventHandler(btnTool_CheckedChanged);
+            // 
+            // chkToolRotate
+            // 
+            chkToolRotate.CheckOnClick = true;
+            chkToolRotate.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            chkToolRotate.ImageTransparentColor = System.Drawing.Color.Magenta;
+            chkToolRotate.Name = "chkToolRotate";
+            chkToolRotate.Size = new System.Drawing.Size(45, 19);
+            chkToolRotate.Text = "Rotate";
+            chkToolRotate.CheckedChanged += new EventHandler(btnTool_CheckedChanged);
+            // 
+            // chkToolScale
+            // 
+            chkToolScale.CheckOnClick = true;
+            chkToolScale.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            chkToolScale.ImageTransparentColor = System.Drawing.Color.Magenta;
+            chkToolScale.Name = "chkToolScale";
+            chkToolScale.Size = new System.Drawing.Size(38, 19);
+            chkToolScale.Text = "Scale";
+            chkToolScale.CheckedChanged += new EventHandler(btnTool_CheckedChanged);
             // 
             // panel2
             // 
@@ -2078,7 +2097,7 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
             _interpolationEditor.Dock = DockStyle.Fill;
             _interpolationEditor.Visible = false;
 
-            cboToolSelect.SelectedIndex = 1;
+            chkToolTranslate.Checked = true;
             chkZoomExtents.Enabled = false;
 
             _currentProjBox = perspectiveToolStripMenuItem;

--- a/BrawlCrate/UI/Model Previewer/ModelEditControl/MiscFunctions.cs
+++ b/BrawlCrate/UI/Model Previewer/ModelEditControl/MiscFunctions.cs
@@ -40,8 +40,25 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
             model.ResetToBindState();
         }
 
-        private void cboToolSelect_SelectedIndexChanged(object sender, EventArgs e)
+
+        private void btnTool_CheckedChanged(object sender, EventArgs e)
         {
+            if (((ToolStripButton)sender).Checked)
+            {
+                if (sender == chkToolTranslate)
+                {
+                    chkToolRotate.Checked = chkToolScale.Checked = false;
+                }
+                else if (sender == chkToolRotate)
+                {
+                    chkToolTranslate.Checked = chkToolScale.Checked = false;
+                }
+                else if (sender == chkToolScale)
+                {
+                    chkToolTranslate.Checked = chkToolRotate.Checked = false;
+                }
+            }
+
             _updating = true;
             switch (ControlType)
             {

--- a/BrawlCrate/UI/Model Previewer/ModelEditControl/Variables.cs
+++ b/BrawlCrate/UI/Model Previewer/ModelEditControl/Variables.cs
@@ -115,15 +115,36 @@ namespace BrawlCrate.UI.Model_Previewer.ModelEditControl
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override TransformType ControlType
         {
-            get => (TransformType) cboToolSelect.SelectedIndex;
+            get
+            {
+                if (chkToolTranslate.Checked)
+                    return TransformType.Translation;
+                if (chkToolRotate.Checked)
+                    return TransformType.Rotation;
+                if (chkToolScale.Checked)
+                    return TransformType.Scale;
+                return TransformType.None;
+            }
             set
             {
-                if ((TransformType) cboToolSelect.SelectedIndex == value)
+                switch (value)
                 {
-                    return;
+                    case TransformType.Translation:
+                        chkToolRotate.Checked = chkToolScale.Checked = false;
+                        chkToolTranslate.Checked = true;
+                        break;
+                    case TransformType.Rotation:
+                        chkToolTranslate.Checked = chkToolScale.Checked = false;
+                        chkToolRotate.Checked = true;
+                        break;
+                    case TransformType.Scale:
+                        chkToolTranslate.Checked = chkToolRotate.Checked = false;
+                        chkToolScale.Checked = true;
+                        break;
+                    default:
+                        chkToolTranslate.Checked = chkToolRotate.Checked = chkToolScale.Checked = false;
+                        break;
                 }
-
-                cboToolSelect.SelectedIndex = (int) value;
             }
         }
 


### PR DESCRIPTION
Replaces the cboToolSelect combo box on the menu bar with Move/Rotate/Scale buttons for easier tool selection with mouse.

Click the current tool button to have None active

![image](https://github.com/user-attachments/assets/e38d2138-e576-4257-8aa4-86ca7a8b6141)
![GIF 2024-07-26 9-34-50](https://github.com/user-attachments/assets/4a5f5673-d4b9-4099-8f39-5c746544a76d)
