### PR TITLE
Fix frame scale calculation

### DIFF
--- a/BrawlLib/Wii/Animations/AnimationConverter.cs
+++ b/BrawlLib/Wii/Animations/AnimationConverter.cs
@@ -1019,10 +1019,14 @@ namespace BrawlLib.Wii.Animations
             int numFrames = kf.FrameLimit;
             KeyframeEntry frame, root = kf._keyArrays[index]._keyRoot;
             bfloat* pVal = (bfloat*) addr;
-            float val, frameScale = numFrames <= 1 ? 1 : 1.0f / (numFrames - 1);
+            float val = numFrames <= 1 ? 1 : 1.0f / (numFrames - 1);
             float min, max, stride, step;
             int span, i;
             int keyCount = kf._keyArrays[index]._keyCount;
+
+            int keyFrameRange = root._prev._index - root._next._index;
+            float oneMinusEpsilon = BitConverter.ToSingle(BitConverter.GetBytes(BitConverter.ToInt32(BitConverter.GetBytes(1.0f), 0) - 1), 0);
+            float frameScale = keyFrameRange == 0 ? 0.0f : oneMinusEpsilon / keyFrameRange;
 
             if (format == AnimDataFormat.L4)
             {


### PR DESCRIPTION
Changes calculation of the "frame scale" field in some animation formats to match berrybush and RiiStudio.

The frame scale field's purpose is for a heuristic that optimizes finding the keyframe interval that corresponds to a current animation frame. It works by calculating the keyframe interval that would be correct assuming they are all uniform, and using that estimate as the starting point from which to traverse keyframes instead of just starting at the beginning or end of the animation.

Computing the frame scale in this corrected way, as not quite the reciprocal of the animation's length but instead short by a sliver, is necessary to avoid an extreme edge case in which this estimation can round up to a nonexistent interval and cause the game to traverse out of bounds keyframes.
For example, in a 500-frame animation with 2 keyframes, if the current frame is the maximum possible value of 499.99997, then the frame scale is (via current BrawlCrate) 1/500 = 0.02, so the estimated keyframe should be calculated as floor(499.99997 * 0.02 * 2) = 1... but for this exact current frame (not one float value less) the multiplication rounds up to 2, which should never occur, and the search begins out of bounds.

This is a major problem because such a current frame can be realized rarely and non-deterministically in Mario Kart Wii map objects, which each randomize their animation speeds to a value near 1 every time the race is reloaded, so any exact float value might be reached after many, many animation loops.
Then, if the ensuing out-of-bounds keyframe traversal ends by returning an extremely large garbage CHR0 rotation angle, code that needs to reign it into a reasonable range freezes the game in an infinite loop as its subtractions can't make progress due to float imprecision.

Curiously, official MKW CHR0 animations seem to use extremely small frame scales (1/32 of what they should be?) that overcorrect for this bug and nullify the benefits of the heuristic. The approach here preserves the heuristic's capability as much as possible without risking the bug.

Additionally, BrawlCrate currently calculates the frame scale based on the animation's frame count, but the keyframe interval search only considers the range between the first and last keyframes (which may be shorter than the full frame count, e.g. 500 frame animation with a first keyframe at frame 60) -- this is also fixed.