### PR TITLE
Named Entries in BRRES External Folder

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/Archives/BRRESNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Archives/BRRESNode.cs
@@ -974,7 +974,12 @@ namespace BrawlLib.SSBB.ResourceNodes
                             new SRT0Node().Initialize(this, hdr, hdr->_size);
                             break;
                         default:
-                            new BRESEntryNode().Initialize(this, hdr, hdr->_size);
+                            BRESEntryNode a = new BRESEntryNode();
+                            a.Initialize(this, hdr, hdr->_size);
+                            if (a._name == null )
+                            {
+                                a._name = group->First[i].GetName();
+                            }
                             break;
                     }
                 }


### PR DESCRIPTION
From a quick test, this at least named the entries in the external folder if nothing else. I do not know more about the project if setting the name this way effects things, but thought it would be a welcome change instead of seeing "<null>" for them all, as seeing the names can give good insight to the file contents.