### PR TITLE
Rel population synchronous

### DIFF
--- a/BrawlLib/App.config
+++ b/BrawlLib/App.config
@@ -62,6 +62,9 @@
             <setting name="ShowProgressBars" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="ApplyRelocationsAsync" serializeAs="String">
+                <value>True</value>
+            </setting>
         </BrawlLib.Properties.Settings>
     </applicationSettings>
 </configuration>

--- a/BrawlLib/Internal/Windows/Forms/TextureConverterDialog.cs
+++ b/BrawlLib/Internal/Windows/Forms/TextureConverterDialog.cs
@@ -459,7 +459,14 @@ namespace BrawlLib.Internal.Windows.Forms
                 chkConstrainProps.Checked = false;
                 numW.Value = InitialSize.Value.Width;
                 numH.Value = InitialSize.Value.Height;
-                btnApplyDims.PerformClick();
+                if (!Automatic)
+                {
+                    btnApplyDims.PerformClick();
+                }
+                else
+                {
+                    ResizeImage(InitialSize.Value.Width, InitialSize.Value.Height);
+                }
             }
 
             if (InitialFormat != null)

--- a/BrawlLib/Properties/Settings.Designer.cs
+++ b/BrawlLib/Properties/Settings.Designer.cs
@@ -300,5 +300,14 @@ namespace BrawlLib.Properties {
                 return ((bool)(this["ShowProgressBars"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ApplyRelocationsAsync {
+            get {
+                return ((bool)(this["ApplyRelocationsAsync"]));
+            }
+        }
     }
 }

--- a/BrawlLib/Properties/Settings.settings
+++ b/BrawlLib/Properties/Settings.settings
@@ -74,5 +74,8 @@
     <Setting Name="ShowProgressBars" Type="System.Boolean" Scope="Application">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ApplyRelocationsAsync" Type="System.Boolean" Scope="Application">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Adds a setting to determine whether or not REL files are populated asynchronously. Also makes it so textures can be resized even when the TextureConverterDialog does not display.