### PR TITLE
Fixed discrepancies in SHP0 format.

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/Animations/SHP0Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Animations/SHP0Node.cs
@@ -742,20 +742,21 @@ namespace BrawlLib.SSBB.ResourceNodes
         public override int OnCalculateSize(bool force)
         {
             _isFixed = Keyframes._keyCount <= 1;
-            return _dataLen = _isFixed ? 0 : Keyframes._keyCount * 12 + 4;
+            return _dataLen = _isFixed ? 0 : Keyframes._keyCount * 12 + 8;
         }
 
         public override void OnRebuild(VoidPtr address, int length, bool force)
         {
             SHP0KeyframeEntries* header = (SHP0KeyframeEntries*) address;
             header->_numEntries = (short) Keyframes._keyCount;
-            header->_unk1 = 0;
+            header->_pad = 0;
+            header->_recip = 1 / (float)(Keyframes._frameLimit - 1);
 
             BVec3* entry = header->Entries;
             KeyframeEntry frame, root = Keyframes._keyRoot;
             for (frame = root._next; frame._index != -1; frame = frame._next)
             {
-                *entry++ = new Vector3(frame._tangent, frame._index, frame._value);
+                *entry++ = new Vector3(frame._index, frame._value, frame._tangent);
             }
         }
 

--- a/BrawlLib/SSBB/Types/Animations/SHP0.cs
+++ b/BrawlLib/SSBB/Types/Animations/SHP0.cs
@@ -188,7 +188,8 @@ namespace BrawlLib.SSBB.Types.Animations
     internal unsafe struct SHP0KeyframeEntries
     {
         public bshort _numEntries;
-        public bshort _unk1;
+        public bshort _pad;
+        public bfloat _recip;
 
         private VoidPtr Address
         {
@@ -201,6 +202,6 @@ namespace BrawlLib.SSBB.Types.Animations
             }
         }
 
-        public BVec3* Entries => (BVec3*) (Address + 4);
+        public BVec3* Entries => (BVec3*) (Address + 8);
     }
 }

--- a/BrawlLib/Wii/Animations/AnimationConverter.cs
+++ b/BrawlLib/Wii/Animations/AnimationConverter.cs
@@ -55,10 +55,12 @@ namespace BrawlLib.Wii.Animations
             }
 
             int fCount = entry->_numEntries;
+            float currentRecip = entry->_recip;
             BVec3* vec = entry->Entries;
+
             for (int i = 0; i < fCount; i++, vec++)
             {
-                kf.SetFrameValue((int) vec->_y, vec->_z, true)._tangent = vec->_x;
+                kf.SetFrameValue((int) vec->_x, vec->_y, true)._tangent = vec->_z;
             }
 
             return kf;


### PR DESCRIPTION
The header was 4 bytes too small, giving the illusion that tangent data came before the frame and value data of a keyframe.